### PR TITLE
Editorconfig had syntax errors in IntelliJ since the proposed pattern…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[{src,scripts}/**.{js,jsx,json,js}]
+[{src,scripts}/**.{js,jsx,json}]
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
@@ -8,6 +8,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.yml,*.yaml]
+[*.{yml,yaml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
… for multiple suffixes is '[*.{aa,bb}]'. 
'js' was doubled.